### PR TITLE
Fr header bidding cookie poc

### DIFF
--- a/modules/cookies.js
+++ b/modules/cookies.js
@@ -21,13 +21,11 @@ export function setConfig(config) {
   if (!config) {
     active = false
     return
-  }
-  else if (!cookiesAreEnabled() && !localStorageIsEnabled()) {
+  } else if (!cookiesAreEnabled() && !localStorageIsEnabled()) {
     active = false
     logWarn('The current browser instance does not support the cookies module.')
     return
-  }
-  else {
+  } else {
     active = true
   }
 
@@ -121,22 +119,19 @@ export function bidWonListener(bid, doc) {
   if (cookieConfig.from.indexOf('creative') !== -1) {
     if (doc.readyState === 'complete') {
       syncData(getDataObj(doc), undefined, {addPrefix: false})
-    }
-    else {
+    } else {
       if (doc.addEventListener) {
         doc.addEventListener('DOMContentLoaded', () => {
           syncData(getDataObj(doc), undefined, {addPrefix: false})
         }, false)
-      }
-      else if (attachEvent) {
+      } else if (attachEvent) {
         doc.attachEvent('onreadystatechange', () => {
           if (document.readyState !== 'complete') {
             return
           }
           syncData(getDataObj(doc), undefined, {addPrefix: false})
         })
-      }
-      else {
+      } else {
         setTimeout(() => {
           syncData(getDataObj(doc), undefined, {addPrefix: false})
         }, 200)
@@ -158,8 +153,7 @@ function localStorageIsEnabled(doc) {
     docWindow.localStorage.setItem('prebid.test', 'prebid.test')
     docWindow.localStorage.removeItem('prebid.test')
     return true
-  }
-  catch (e) {
+  } catch (e) {
     return false
   }
 }
@@ -191,8 +185,7 @@ function syncData(data, doc, options = {}) {
           }
           setCookie(name, data[key], cookieConfig.expires, cookieConfig.sameSite, doc)
           return true
-        }
-        else if (storage === 'localStorage') {
+        } else if (storage === 'localStorage') {
           if (!localStorageIsEnabled(doc)) {
             return false
           }
@@ -225,15 +218,13 @@ function getDataObj(doc) {
           let value = match[2]
           try {
             value = decodeURIComponent(value)
-          }
-          catch (e) { /* set original */
+          } catch (e) { /* set original */
           }
           cookies[name] = value
         }
         return cookies
       }, {})
-  }
-  catch (e) { /* can not access cookies */
+  } catch (e) { /* can not access cookies */
   }
 
   let storage = {}
@@ -243,8 +234,7 @@ function getDataObj(doc) {
       storage[key] = docWindow.localStorage.getItem(key)
       return storage
     }, {})
-  }
-  catch (e) { /* can not access localStorage */
+  } catch (e) { /* can not access localStorage */
   }
 
   return Object.assign(cookies, storage)

--- a/modules/cookies.js
+++ b/modules/cookies.js
@@ -1,0 +1,251 @@
+import {config} from '../src/config.js';
+import {cookiesAreEnabled, setCookie, logInfo, logWarn} from '../src/utils.js'
+
+let cookieConfig = {}
+let enabled = false
+let active = false
+
+/**
+ * Configures the `cookies` namespace.
+ * Adds a requestBid-hook, a bidWon listener, and a bidResponse listener if the module is enabled.
+ *
+ * @param {object} config - Configuration object.
+ * @param {string} config.namespace - Namespace of cookies that will be set and send.
+ * @param {string} config.prefix - Adds a prefix when storing data. Prefix is removed when data is send.
+ * @param {array<string>} config.from - Limits the cookies to set. Possible values: `creative`, `winningBidResponse`, `bidResponse`
+ * @param {array<string>} config.storages - Storage to use to store data. Can be: `cookies` or `localStorage`.
+ * @param {string} config.expires - Sane-cookie-date. Only in cookies-store.
+ * @param {string} config.sameSite - Set to `Lax` to send cookies to third parties. Only in cookies-store.
+ */
+export function setConfig(config) {
+  if (!config) {
+    active = false
+    return
+  }
+  else if (!cookiesAreEnabled() && !localStorageIsEnabled()) {
+    active = false
+    logWarn('The current browser instance does not support the cookies module.')
+    return
+  }
+  else {
+    active = true
+  }
+
+  // default values
+  if (typeof config !== 'object') {
+    config = {}
+  }
+  config.namespace = config.namespace || 'prebid.'
+  config.prefix = config.prefix || (config.namespace === '*' ? '' : 'prebid.')
+  config.storages = Array.isArray(config.storages) ? config.storages : (config.storages ? [config.storages] : ['cookies', 'localStorage'])
+  config.from = Array.isArray(config.from) ? config.from : (config.from ? [config.from] : ['creative', 'winningBidResponse', 'bidResponse'])
+
+  // make the cookie config native to this module
+  cookieConfig = config
+
+  if (!enabled) {
+    enabled = true
+    $$PREBID_GLOBAL$$.onEvent('bidRequested', bidRequestedListener)
+    $$PREBID_GLOBAL$$.onEvent('bidResponse', bidResponseListener)
+    $$PREBID_GLOBAL$$.onEvent('bidWon', bidWonListener)
+    logInfo('The cookies module is enabled.', cookieConfig)
+  }
+}
+
+config.getConfig('cookies', config => setConfig(config.cookies))
+
+/**
+ * Adds the cookies property to the bidderRequest of buildRequests.
+ *
+ * @param {object} bidRequest - Bid request configuration.
+ */
+export function bidRequestedListener(bidRequest) {
+  if (active) {
+    const cookies = getDataObj(document)
+    const data = Object.keys(cookies).reduce((data, key) => {
+      if (!(key.startsWith(cookieConfig.namespace))) {
+        return data
+      }
+      const value = cookies[key]
+      if (cookieConfig.prefix && key.startsWith(cookieConfig.prefix)) {
+        key = key.substr(cookieConfig.prefix.length)
+      }
+      data[key] = value
+      return data
+    }, {})
+
+    // it is up to the adapter to merge the bidderRequest.cookies in buildRequests
+    // into the bidderRequest (for example as options.customHeaders['Cookie'])
+    bidRequest.cookies = data
+  }
+}
+
+/**
+ * Calls syncData for the `document` of a winning bid.
+ *
+ * Sets `cookies` from the bid response to the main frame.
+ * It is up to the adapter to set the `cookies`-property of a bid or not.
+ *
+ * Example for interpretResponse:
+ * bid.cookies = JSON.parse(serverResponse.headers.get('X-Set-Cookie-JSON'))
+ *
+ * @param {object} bid - bid response.
+ */
+export function bidResponseListener(bid) {
+  if (!active || !bid.cookies || cookieConfig.from.indexOf('bidResponse') === -1) {
+    return
+  }
+  syncData(bid.cookies, undefined, {addPrefix: true})
+}
+
+/**
+ * Calls syncData for the `document` of a winning bid.
+ *
+ * @param {object} bid - Bid object.
+ */
+export function bidWonListener(bid, doc) {
+  if (!active) {
+    return
+  }
+
+  // set cookies from the bid response to the main frame
+  if (bid.cookies && (cookieConfig.from.indexOf('bidResponse') !== -1 || cookieConfig.from.indexOf('winningBidResponse') !== -1)) {
+    syncData(bid.cookies, undefined, {addPrefix: true})
+  }
+
+  // Set cookies from the main frame in the creative frame.
+  syncData(getDataObj(document), doc, {addPrefix: false, removePrefix: true})
+
+  // Set cookies from the completed creative frame to the main frame.
+  // Do not add prefixes - the purpose of cookies is not unique to this module.
+  if (cookieConfig.from.indexOf('creative') !== -1) {
+    if (doc.readyState === 'complete') {
+      syncData(getDataObj(doc), undefined, {addPrefix: false})
+    }
+    else {
+      if (doc.addEventListener) {
+        doc.addEventListener('DOMContentLoaded', () => {
+          syncData(getDataObj(doc), undefined, {addPrefix: false})
+        }, false)
+      }
+      else if (attachEvent) {
+        doc.attachEvent('onreadystatechange', () => {
+          if (document.readyState !== 'complete') {
+            return
+          }
+          syncData(getDataObj(doc), undefined, {addPrefix: false})
+        })
+      }
+      else {
+        setTimeout(() => {
+          syncData(getDataObj(doc), undefined, {addPrefix: false})
+        }, 200)
+      }
+    }
+  }
+}
+
+/**
+ * Checks if the localStorage is available.
+ *
+ * @params {Document} doc - Document to check for availability.
+ *
+ * @returns {boolean} - `true` if localStorage can be used
+ */
+function localStorageIsEnabled(doc) {
+  try {
+    const docWindow = (doc) ? (doc.parentWindow || doc.defaultView) : window
+    docWindow.localStorage.setItem('prebid.test', 'prebid.test')
+    docWindow.localStorage.removeItem('prebid.test')
+    return true
+  }
+  catch (e) {
+    return false
+  }
+}
+
+/**
+ * Sets the passed key-values as cookies or localStorage in a document.
+ *
+ * @param {object} data - Key-Value pairs of cookies that will be set in the document.
+ * @param {Document} document - Document. Defaults to the current document.
+ * @param {object} options - Additional configuration.
+ * @param {boolean} options.addPrefix - Adds the prefix when setting data.
+ */
+function syncData(data, doc, options = {}) {
+  Object.keys(data).forEach((key) => {
+    let name = key
+    if (options.addPrefix && cookieConfig.prefix && key.indexOf(cookieConfig.prefix) !== 0) {
+      name = cookieConfig.prefix + key
+    }
+
+    if (cookieConfig.namespace === '*' || name.startsWith(cookieConfig.namespace)) {
+      if (options.removePrefix && name.startsWith(cookieConfig.prefix)) {
+        name = name.substr(cookieConfig.prefix.length)
+      }
+
+      cookieConfig.storages.find((storage) => {
+        if (storage === 'cookies') {
+          if (!cookiesAreEnabled()) {
+            return false
+          }
+          setCookie(name, data[key], cookieConfig.expires, cookieConfig.sameSite, doc)
+          return true
+        }
+        else if (storage === 'localStorage') {
+          if (!localStorageIsEnabled(doc)) {
+            return false
+          }
+          const docWindow = (doc) ? (doc.parentWindow || doc.defaultView) : window
+          docWindow.localStorage.setItem(name, data[key])
+          return true
+        }
+        return false
+      })
+    }
+  })
+}
+
+/**
+ * Retrieves all data (cookie and localStorage) from a given document into a key-value object.
+ *
+ * @param {Document} doc - Document object that will be parsed for cookies.
+ *
+ * @returns {object} - A key-value-object.
+ */
+function getDataObj(doc) {
+  let cookies = {}
+  try {
+    cookies = doc.cookie
+      .split('; ')
+      .reduce((cookies, cookie) => {
+        const match = cookie.match(/([^\=]*)=(.*)/)
+        if (match) {
+          const name = match[1]
+          let value = match[2]
+          try {
+            value = decodeURIComponent(value)
+          }
+          catch (e) { /* set original */
+          }
+          cookies[name] = value
+        }
+        return cookies
+      }, {})
+  }
+  catch (e) { /* can not access cookies */
+  }
+
+  let storage = {}
+  try {
+    const docWindow = (doc) ? (doc.parentWindow || doc.defaultView) : window
+    storage = Object.keys(docWindow.localStorage).reduce((storage, key) => {
+      storage[key] = docWindow.localStorage.getItem(key)
+      return storage
+    }, {})
+  }
+  catch (e) { /* can not access localStorage */
+  }
+
+  return Object.assign(cookies, storage)
+}

--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -11,7 +11,12 @@ const BIDDER_CODE = 'stroeerCore';
 const DEFAULT_HOST = 'hb.adscale.de';
 const DEFAULT_PATH = '/dsh';
 const DEFAULT_PORT = '';
+
 const USER_ID_COOKIE_NAME = 'stroeer-uid';
+const USER_ID_COOKIE_EXPIRY_DAYS = 30;
+const USER_ID_COOKIE_EXPIRY_DELTA_MILLIS = USER_ID_COOKIE_EXPIRY_DAYS * 60 * 60 * 1000 * 24;
+
+const getUserIdCookieExpiryDate = () => new Date(new Date().getTime() + USER_ID_COOKIE_EXPIRY_DELTA_MILLIS).toUTCString();
 
 const _externalCrypter = new Crypter('c2xzRWh5NXhpZmxndTRxYWZjY2NqZGNhTW1uZGZya3Y=', 'eWRpdkFoa2tub3p5b2dscGttamIySGhkZ21jcmg0Znk=');
 const _internalCrypter = new Crypter('1AE180CBC19A8CFEB7E1FCC000A10F5D892A887A2D9=', '0379698055BD41FD05AC543A3AAAD6589BC6E1B3626=');
@@ -120,7 +125,7 @@ function initUserConnect() {
 const saveUserId = responseBody => {
   if (!responseBody.ext || !responseBody.ext.buyeruid) return;
 
-  setCookie(USER_ID_COOKIE_NAME, responseBody.ext.buyeruid)
+  setCookie(USER_ID_COOKIE_NAME, responseBody.ext.buyeruid, getUserIdCookieExpiryDate())
 };
 
 export const spec = {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -242,7 +242,7 @@ $$PREBID_GLOBAL$$.renderAd = function (doc, id) {
         auctionManager.addWinningBid(bid);
 
         // emit 'bid won' event here
-        events.emit(BID_WON, bid);
+        events.emit(BID_WON, bid, doc);
 
         const { height, width, ad, mediaType, adUrl, renderer } = bid;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -826,6 +826,27 @@ export function cookiesAreEnabled() {
   return window.document.cookie.indexOf('prebid.cookieTest') != -1;
 }
 
+export function getCookie(name) {
+  let m = window.document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]*)\\s*(;|$)');
+  return m ? decodeURIComponent(m[2]) : null;
+}
+
+export function setCookie(key, value, expires, sameSite, doc) {
+  (doc || document).cookie = `${key}=${encodeURIComponent(value)}${(expires !== '') ? `; expires=${expires}` : ''}; path=/${sameSite ? `; SameSite=${sameSite}` : ''}`;
+}
+
+/**
+ * @returns {boolean}
+ */
+export function localStorageIsEnabled () {
+  try {
+    localStorage.setItem('prebid.cookieTest', '1');
+    return localStorage.getItem('prebid.cookieTest') === '1';
+  } catch (error) {
+    return false;
+  }
+}
+
 /**
  * Given a function, return a function which only executes the original after
  * it's been called numRequiredCalls times.

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -517,7 +517,6 @@ describe('33acrossBidAdapter:', function () {
               bid: [{
                 id: '1',
                 adm: '<html><h3>I am an ad</h3></html>',
-                crid: 1,
                 h: 250,
                 w: 300,
                 price: 0.0940,
@@ -526,7 +525,6 @@ describe('33acrossBidAdapter:', function () {
               {
                 id: '2',
                 adm: '<html><h3>I am an ad</h3></html>',
-                crid: 2,
                 h: 250,
                 w: 300,
                 price: 0.0938,


### PR DESCRIPTION
In order to prove the first party cookie could be used. We save the `response.ext.buyeruid` into stroeer cookie named `stroeer-uid` with 30 days expiry from bid response, and pass the value with `request.user.buyeruid`.

What's in this PR?

- Copy PR content from Pascal. https://github.com/prebid/Prebid.js/pull/4440/files
- Populate bid request with `stroeer-uid`
- Save `stroeer-uid` from bid response


