### PR TITLE
Do not send inventory context when Metatag is not found on website

### DIFF
--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -200,14 +200,20 @@ export const spec = {
         sid: bid.params.sid,
         siz: bidSizes(bid),
         viz: elementInView(bid.adUnitCode),
-        ctx: {
+        ctx: getContextFromSDG(bid)
+      });
+    });
+
+    function getContextFromSDG(bid) {
+      if (win.SDG) {
+        return {
           position: bid.adUnitCode,
           adUnits: getAdUnits(bid.adUnitCode),
           zone: getZone(bid.adUnitCode),
           pageType: getPageType(bid.adUnitCode),
         }
-      });
-    });
+      }
+    }
 
     return {
       method: 'POST', url: buildUrl(anyBid.params), data: payload

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -474,17 +474,11 @@ describe('stroeerCore bid adapter', function () {
             'bid': 'bid1',
             'siz': [[300, 600], [160, 60]],
             'viz': true,
-            'ctx': {
-              'position': 'div-1'
-            }
           }, {
             'sid': 'ODA=',
             'bid': 'bid2',
             'siz': [[728, 90]],
             'viz': true,
-            'ctx': {
-              'position': 'div-2'
-            }
           }],
           'user': {
             'euids': userIds
@@ -558,6 +552,18 @@ describe('stroeerCore bid adapter', function () {
         const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq);
         assert.deepEqual(serverRequestInfo.data.bids[0].siz, [[300, 600], [160, 60]]);
         assert.deepEqual(serverRequestInfo.data.bids[1].siz, [[728, 90]]);
+      });
+
+      describe('when Metatag is not present on webpage', () => {
+        it('should not build context into bid property ctx', () => {
+          win.SDG = undefined;
+
+          const bidReq = buildBidderRequest();
+
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq);
+
+          assert.equal(serverRequestInfo.data.bids[0].ctx, undefined);
+        });
       });
 
       describe('optional fields', () => {


### PR DESCRIPTION
In case there is no Metatag on a page we also do not expect to receive any context and should ignore anything that comes our way looking like context. 