### PR TITLE
StroeerCoreBidAdapter: passes userIdAsEids to the server

### DIFF
--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -205,6 +205,7 @@ export const spec = {
 
     const user = utils.cleanObj({
       euids: anyBid.userId,
+      eids: bidderRequest.userIdAsEids,
       data: utils.deepAccess(bidderRequest, 'ortb2.user.data')
     });
 

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -85,6 +85,22 @@ describe('stroeerCore bid adapter', function() {
     }
   });
 
+  // Pub Provided ids
+  const userIdAsEids = Object.freeze([
+    {
+      source: 'stroeer.de',
+      uids: [
+        {
+          id: 'db1747db-a0c6-42e7-9387-ace49d2f80b7',
+          atype: 1,
+          ext: {
+            stype: 'ppuid'
+          }
+        }
+      ]
+    }
+  ])
+
   const buildBidderRequest = () => ({
     bidderRequestId: 'bidder-request-id-123',
     bidderCode: 'stroeerCore',
@@ -94,6 +110,7 @@ describe('stroeerCore bid adapter', function() {
       page: 'https://www.example.com/monkey/index.html',
       ref: 'https://www.example.com/?search=monkey'
     },
+    userIdAsEids: userIdAsEids,
     bids: [{
       bidId: 'bid1',
       bidder: 'stroeerCore',
@@ -568,6 +585,7 @@ describe('stroeerCore bid adapter', function() {
           }],
           'ver': {},
           'user': {
+            'eids': userIdAsEids,
             'euids': userIds
           }
         };
@@ -1018,7 +1036,15 @@ describe('stroeerCore bid adapter', function() {
           bidReq.bids.forEach(bid => delete bid.userId);
           const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
           assert.lengthOf(serverRequestInfo.data.bids, 2);
-          assert.notProperty(serverRequestInfo, 'uids');
+          assert.notProperty(serverRequestInfo.data.user, 'euids');
+        });
+
+        it('should be able to build without userIdAsEids', () => {
+          const bidReq = buildBidderRequest();
+          bidReq.userIdAsEids = undefined
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
+          assert.lengthOf(serverRequestInfo.data.bids, 2);
+          assert.notProperty(serverRequestInfo.data.user, 'eids');
         });
 
         it('should add schain if available', () => {


### PR DESCRIPTION
We would like to use the PubProvidedId module. The ids provided by the module only accessible via the userIdAsEids field.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
