### PR TITLE
Changes for enabling price prediction on sites without meta tag

### DIFF
--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -3,6 +3,7 @@ import { ajax } from '../src/ajax.js'
 import { BANNER, VIDEO } from '../src/mediaTypes.js'
 import * as utils from '../src/utils.js'
 import { getGlobal } from '../src/prebidGlobal.js'
+import { config } from '../src/config.js'
 
 const GVL_ID = 136;
 const BIDDER_CODE = 'stroeerCore';
@@ -376,7 +377,7 @@ export const spec = {
 
     function getGlobalKeyValues() {
       try {
-        return getValidKeyValues(win.SDG.Publisher.getConfig().getFilteredKeyValues());
+        return win.SDG ? getValidKeyValues(win.SDG.Publisher.getConfig().getFilteredKeyValues()) : config.getConfig('kvg');
       } catch (e) {
         return undefined;
       }

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -5,6 +5,7 @@ import { BANNER, VIDEO } from '../../../src/mediaTypes.js';
 import * as prebidGlobal from '../../../src/prebidGlobal';
 import sinon from 'sinon';
 import * as ajax from 'src/ajax.js';
+import { config } from "../../../src/config";
 
 describe('stroeerCore bid adapter', function() {
   let sandbox;
@@ -765,6 +766,42 @@ describe('stroeerCore bid adapter', function() {
               }
             }
           }
+        });
+      });
+
+      describe('and when metatag is not available', () => {
+        const keyValues = { 'key0': 'value0', 'key1': 'value1' };
+        let getConfigStub;
+
+        beforeEach(() => {
+          assert.isUndefined(win.SDG);
+          getConfigStub = sinon.stub(config, 'getConfig');
+        });
+
+        afterEach(() => {
+          config.getConfig.restore();
+        });
+
+        it('should fallback to kvg config for global key values', () => {
+          getConfigStub.withArgs('kvg').returns(utils.deepClone(keyValues));
+
+          const bidReq = buildBidderRequest();
+
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
+
+          assert.deepEqual(serverRequestInfo.data.kvg, keyValues);
+          assert.isTrue(config.getConfig.calledOnce);
+        });
+
+        it('should handle no kvg config', () => {
+          getConfigStub.withArgs('kvg').returns(undefined);
+
+          const bidReq = buildBidderRequest();
+
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
+
+          assert.isUndefined(serverRequestInfo.data.kvg);
+          assert.isTrue(config.getConfig.calledOnce);
         });
       });
 


### PR DESCRIPTION

## Description of change
Previously on sites with only the YL wrapper, the key value pair `yt` was never expected to be sent to Stroeer SSP since it was exclusively used as a signal by Meta tag for enabling price optimization. However, since we now desire the same functionality on wrapper only sites, the _getGlobalKeyValues_ function needed to be changed.

