### PR TITLE
updates getGlobalKeyValues func logic and it's related tests

### DIFF
--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -378,11 +378,16 @@ export const spec = {
     }
 
     function getGlobalKeyValues() {
+      const kvgConfig = config.getConfig('kvg');
+      const configKeyValues = utils.isPlainObject(kvgConfig) ? getValidKeyValues(kvgConfig) : {};
+      let metaTagKeyValues = {};
+
       try {
-        return win.SDG ? getValidKeyValues(win.SDG.Publisher.getConfig().getFilteredKeyValues()) : config.getConfig('kvg');
-      } catch (e) {
-        return undefined;
+        metaTagKeyValues = getValidKeyValues(win.SDG.Publisher.getConfig().getFilteredKeyValues());
+      } catch (ignore) {
       }
+
+      return { ...metaTagKeyValues, ...configKeyValues };
     }
 
     function getLocalKeyValues(metaTagPosition) {

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -860,6 +860,17 @@ describe('stroeerCore bid adapter', function() {
         });
 
         it('should handle no kvg config', () => {
+          getConfigStub.withArgs('kvg').returns(undefined);
+
+          const bidReq = buildBidderRequest();
+
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
+
+          assert.deepEqual(serverRequestInfo.data.kvg, {});
+          assert.isTrue(config.getConfig.calledOnce);
+        });
+
+        it('should handle empty kvg config', () => {
           getConfigStub.withArgs('kvg').returns({});
 
           const bidReq = buildBidderRequest();

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -798,30 +798,41 @@ describe('stroeerCore bid adapter', function() {
           }
         });
 
-        it('config key values should override identical metatag key values', () => {
-          win.SDG = buildFakeSDGForGlobalKeyValues({
-            source: ['metatag'],
-            metaTagKey: ['random'],
+        describe('config handling', () => {
+          let getConfigStub;
+
+          beforeEach(() => {
+            getConfigStub = sinon.stub(config, 'getConfig');
           });
 
-          const configKeyValues = {
-            source: ['config'],
-          };
+          afterEach(() => {
+            config.getConfig.restore();
+          });
 
-          const getConfigStub = sinon.stub(config, 'getConfig');
-          getConfigStub.withArgs('kvg').returns(utils.deepClone(configKeyValues));
+          it('should merge key values with config key values taking precedence', () => {
+            win.SDG = buildFakeSDGForGlobalKeyValues({
+              source: ['metatag'],
+              metaTagKey: ['metatagValue'],
+            });
 
-          const bidReq = buildBidderRequest();
-          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
+            const configKeyValues = {
+              source: ['config'],
+              configKey: ['configValue'],
+            };
 
-          const expectedResult = {
-            source: ['config'],
-            metaTagKey: ['random'],
-          };
+            getConfigStub.withArgs('kvg').returns(configKeyValues);
 
-          assert.deepEqual(serverRequestInfo.data.kvg, expectedResult);
+            const bidReq = buildBidderRequest();
+            const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
 
-          config.getConfig.restore();
+            const expectedResult = {
+              source: ['config'],
+              metaTagKey: ['metatagValue'],
+              configKey: ['configValue'],
+            };
+
+            assert.deepEqual(serverRequestInfo.data.kvg, expectedResult);
+          });
         });
       });
 

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -581,6 +581,7 @@ describe('stroeerCore bid adapter', function() {
           'ref': 'https://www.example.com/?search=monkey',
           'mpa': true,
           'url': 'https://www.example.com/monkey/index.html',
+          'kvg': {},
           'bids': [{
             'sid': 'NDA=',
             'bid': 'bid1',
@@ -799,9 +800,8 @@ describe('stroeerCore bid adapter', function() {
       });
 
       describe('and when metatag is not available', () => {
-        const keyValues = { 'key0': 'value0', 'key1': 'value1' };
+        const keyValues = { 'key0': ['value0'], 'key1': ['value1'] };
         let getConfigStub;
-
         beforeEach(() => {
           assert.isUndefined(win.SDG);
           getConfigStub = sinon.stub(config, 'getConfig');
@@ -823,13 +823,13 @@ describe('stroeerCore bid adapter', function() {
         });
 
         it('should handle no kvg config', () => {
-          getConfigStub.withArgs('kvg').returns(undefined);
+          getConfigStub.withArgs('kvg').returns({});
 
           const bidReq = buildBidderRequest();
 
           const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
 
-          assert.isUndefined(serverRequestInfo.data.kvg);
+          assert.deepEqual(serverRequestInfo.data.kvg, {});
           assert.isTrue(config.getConfig.calledOnce);
         });
       });

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -797,6 +797,32 @@ describe('stroeerCore bid adapter', function() {
             }
           }
         });
+
+        it('config key values should override identical metatag key values', () => {
+          win.SDG = buildFakeSDGForGlobalKeyValues({
+            source: ['metatag'],
+            metaTagKey: ['random'],
+          });
+
+          const configKeyValues = {
+            source: ['config'],
+          };
+
+          const getConfigStub = sinon.stub(config, 'getConfig');
+          getConfigStub.withArgs('kvg').returns(utils.deepClone(configKeyValues));
+
+          const bidReq = buildBidderRequest();
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq)[0];
+
+          const expectedResult = {
+            source: ['config'],
+            metaTagKey: ['random'],
+          };
+
+          assert.deepEqual(serverRequestInfo.data.kvg, expectedResult);
+
+          config.getConfig.restore();
+        });
       });
 
       describe('and when metatag is not available', () => {


### PR DESCRIPTION
**Overview**
These changes were introduced in order for the Wrapper to exclusively set the price optimization signal: `kvg.yt`.

**Changes:**
- `getGlobalKeyValues` still retrieves the MetaTag key values, but they are now also merged with the `kvg` values located in the global Prebid config (wrapper sets it). 
- Updated test `kvg` key values since this seems to be the standard. The new validator function also expects the values to be of the type `array[string | number]`.
- The return type will always be an `object` and not `undefined` | `object`. Thus, tests relying on the return value being `undefined` needed to be updated

**Questions**
Is there any other underlying logic that expects `kvg` to sometimes be `undefined` instead of an empty `object`?